### PR TITLE
Fix tag inclusion and exclusion

### DIFF
--- a/wallhaven/utils/params.py
+++ b/wallhaven/utils/params.py
@@ -16,9 +16,9 @@ def make_query(filters: Dict) -> str:
         query += "id:" + filters["id"]
     else:
         for tag in filters["tags"]["excluded"]:
-            query += "-" + tag
+            query += " -" + tag
         for tag in filters["tags"]["included"]:
-            query += "+" + tag
+            query += " +" + tag
 
     # Check keyword
     if filters["keyword"]:


### PR DESCRIPTION
Currently the tag exclusion has no effect (for instance, try including "windows" and excluding "microsoft", it will still show Microsoft Windows wallpapers).

This PR fixes it.